### PR TITLE
B2tweaks

### DIFF
--- a/sspa
+++ b/sspa
@@ -33,7 +33,7 @@ function check_node_deps() {
 
 function dev_server() {
   cd public
-  if type -p livereloadx &>/dev/null ; then
+  if which livereloadx > /dev/null ; then
     exec livereloadx -s -p 9292 "$PWD" 
   else
     exec python -m SimpleHTTPServer 9292

--- a/sspa
+++ b/sspa
@@ -33,7 +33,11 @@ function check_node_deps() {
 
 function dev_server() {
   cd public
-  exec python -m SimpleHTTPServer 9292
+  if type -p livereloadx &>/dev/null ; then
+    exec livereloadx -s -p 9292 "$PWD" 
+  else
+    exec python -m SimpleHTTPServer 9292
+  fi
 }
 
 function create_s3_bucket() {


### PR DESCRIPTION
Prefer serving with livereloadx

It took me a while to figure livereloadx out, but it's really quite simple. No browser integration or source code changes are needed for "static mode" which works fine for learnjs style apps.

With these changes to the "server" function, all someone has to do to get live reload is install livereloadx per:
    http://nitoyon.github.io/livereloadx/
