### PR TITLE
Fix 'endpoint' string pattern.

### DIFF
--- a/sspa
+++ b/sspa
@@ -44,7 +44,7 @@ function create_s3_bucket() {
   if [[ ! -e ${bucket_path}/endpoint.txt ]]; then
     aws --profile $profile s3 mb $bucket_uri && mkdir -p ${bucket_path}
     local region=$(aws --profile $profile configure get region)
-    local endpoint="http://${1}.s3-website-${region}.amazonaws.com"
+    local endpoint="http://${1}.s3-website.${region}.amazonaws.com"
     echo "$endpoint" > ${bucket_path}/endpoint.txt
     echo "Website endpoint is: $endpoint"
   fi


### PR DESCRIPTION
In book section Creating S3 Bucket, after running the 'create_bucket' action, the website endpoint I got, cannot be accessed. For example:
http://learnjs.houstairs.com.s3-website-eu-central-1.amazonaws.com
Checking the S3 bucket in my AWS console, I see that the Static Website Hosting points to:
Endpoint: learnjs.houstairs.com.s3-website.eu-central-1.amazonaws.com
With a dot instead of a dash just after 'website'.
