### PR TITLE
Master

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,13 +13,17 @@
       body { margin-top: 30px; }
     </style>
   </head>
-  <body>
-    <div class='container'>
-      <h1>It works!</h1>
-      <div>
-        <span>You're ready to start!</span>
-        <span>Skeleton 2, jQuery 2, and AWS Libraries are included.</span>
-      </div>
-    </div>
-  </body>
+“<body>
+	  <div class= 'container' >
+	    <div class= 'row' >
+	      <div class= 'one-half column' >
+	        <h3>Learn JavaScript, one puzzle at a time.</h3>
+	        <a href= ''  class= 'button button-primary' >Start Now!</a>
+	      </div>
+	      <div class= 'one-half column' >
+	        <img src= '/images/HeroImage.jpg' />
+	      </div>
+	    </div>
+	  </div>
+	</body>”
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -13,17 +13,13 @@
       body { margin-top: 30px; }
     </style>
   </head>
-“<body>
-	  <div class= 'container' >
-	    <div class= 'row' >
-	      <div class= 'one-half column' >
-	        <h3>Learn JavaScript, one puzzle at a time.</h3>
-	        <a href= ''  class= 'button button-primary' >Start Now!</a>
-	      </div>
-	      <div class= 'one-half column' >
-	        <img src= '/images/HeroImage.jpg' />
-	      </div>
-	    </div>
-	  </div>
-	</body>”
+  <body>
+    <div class='container'>
+      <h1>It works!</h1>
+      <div>
+        <span>You're ready to start!</span>
+        <span>Skeleton 2, jQuery 2, and AWS Libraries are included.</span>
+      </div>
+    </div>
+  </body>
 </html>

--- a/sspa
+++ b/sspa
@@ -33,7 +33,11 @@ function check_node_deps() {
 
 function dev_server() {
   cd public
-  exec python -m SimpleHTTPServer 9292
+  if ! which c9 > /dev/null; then
+  exec python -m SimpleHTTPServer 9292;
+  elif which c9 > /dev/null; then
+  exec python -m SimpleHTTPServer $PORT;
+  fi
 }
 
 function livereload_server() {


### PR DESCRIPTION
When running `./sspa server` on Cloud9's IDE the `exec python -m SimpleHTTPServer 9292` line fails due to incorrect port usage. Cloud9 documentation recommends using `$PORT` instead of hard assignments.

Added detection and react accordingly.
