### PR TITLE
Fixed access rights for lambda service

### DIFF
--- a/sspa
+++ b/sspa
@@ -196,6 +196,7 @@ function build_bundle() {
   cp -r node_modules dist/
   cp -r lib/* dist/
   cd dist
+  chmod -R a+r *
   zip -r archive.zip *
   mv archive.zip ..
   cd ..


### PR DESCRIPTION
I had problems with the lambda service parts of the script because of a restrictive create mask. All files in my home directory are not world-readable. This fixes this.
