### PR TITLE
fixed for python3

### DIFF
--- a/support/jsed.py
+++ b/support/jsed.py
@@ -13,5 +13,5 @@ def search(d, keys):
     else:
         return search(d[keys[0]], keys[1:])
 
-print search(doc, keys)
+print( search(doc, keys) )
 


### PR DESCRIPTION
python3 in Bash on Ubuntu on Windows encountered error for print statement in support/jsed.py.
So I added brackets for print in jsed.py to be safe about python3 and python2.